### PR TITLE
fix(extraction): preserve setup_timestamp when setup is skipped

### DIFF
--- a/goliat/profiler.py
+++ b/goliat/profiler.py
@@ -104,7 +104,7 @@ class Profiler:
         """Ends current phase and records its duration for future estimates."""
         if self.phase_start_time:
             elapsed = time.monotonic() - self.phase_start_time
-            
+
             # For setup phase: if it was cached/skipped, don't add to statistics
             # (cached phases pollute real execution time statistics)
             if self.current_phase == "setup" and self.phase_skipped:
@@ -117,7 +117,7 @@ class Profiler:
                 times = self.subtask_times[self.current_phase]
                 # Store simple average for pie charts, timings table, etc.
                 self.profiling_config[f"avg_{self.current_phase}_time"] = sum(times) / len(times)
-        
+
         self.current_phase = None
         self.phase_skipped = False  # Reset for next phase
 
@@ -187,30 +187,30 @@ class Profiler:
 
     def _get_smart_phase_estimate(self, phase: str) -> float:
         """Computes a robust, recent-weighted estimate for a phase.
-        
+
         Emphasizes the last 3 simulations while using all available data.
         Uses weighted average where recent measurements get higher weights.
-        
+
         Args:
             phase: Phase name ('setup', 'run', or 'extract')
-            
+
         Returns:
             Estimated time in seconds for this phase
         """
         times = self.subtask_times.get(phase, [])
-        
+
         if not times:
             # No data yet - use saved average or default
             return self.profiling_config.get(f"avg_{phase}_time", 60)
-        
+
         if len(times) == 1:
             # Only one measurement - use it
             return times[0]
-        
+
         # Emphasize last 3 simulations with weighted average
         # Last 3 get 70% of total weight, remaining get 30%
         # Within last 3: most recent gets highest weight (0.5), then 0.3, then 0.2
-        
+
         if len(times) >= 3:
             # Get last 3 measurements (oldest to newest)
             last_3 = times[-3:]
@@ -218,7 +218,7 @@ class Profiler:
             # Most recent (last element) gets highest weight
             last_3_weights = [0.2, 0.3, 0.5]  # Most recent gets highest weight
             last_3_total_weight = sum(last_3_weights)
-            
+
             # Remaining measurements (all except last 3) get equal weight
             remaining = times[:-3]
             if remaining:
@@ -226,11 +226,11 @@ class Profiler:
                 # Remaining gets 30% of total weight, last 3 gets 70%
                 remaining_weight = 0.3
                 last_3_weight = 0.7
-                
+
                 # Normalize last_3 weights to sum to last_3_weight (0.7)
                 normalized_last_3_weights = [w * last_3_weight / last_3_total_weight for w in last_3_weights]
                 last_3_weighted_sum = sum(t * w for t, w in zip(last_3, normalized_last_3_weights))
-                
+
                 estimate = last_3_weighted_sum + remaining_avg * remaining_weight
             else:
                 # Only 3 measurements total - use weighted average
@@ -240,7 +240,7 @@ class Profiler:
             # Most recent gets higher weight
             weights = [0.6, 0.4] if len(times) == 2 else [1.0]
             estimate = sum(t * w for t, w in zip(times, weights)) / sum(weights)
-        
+
         return estimate
 
     def get_time_remaining(self, current_stage_progress: float = 0.0) -> float:

--- a/goliat/project_manager.py
+++ b/goliat/project_manager.py
@@ -183,7 +183,7 @@ class ProjectManager(LoggingMixin):
             if output_filename.endswith("_Output.h5"):
                 hash_prefix = output_filename[:-10]  # Remove "_Output.h5" suffix
                 input_file_path = os.path.join(results_dir, f"{hash_prefix}_Input.h5")
-                
+
                 if os.path.exists(input_file_path):
                     output_size = os.path.getsize(h5_file_path)
                     input_size = os.path.getsize(input_file_path)
@@ -196,7 +196,7 @@ class ProjectManager(LoggingMixin):
             else:
                 # Fallback: if filename doesn't match expected pattern, use original check
                 is_valid_output = True
-        
+
         if is_valid_output:
             status["run_done"] = True
         else:

--- a/goliat/studies/far_field_study.py
+++ b/goliat/studies/far_field_study.py
@@ -151,6 +151,10 @@ class FarFieldStudy(BaseStudy):
                         project_dir = os.path.dirname(self.project_manager.project_path)
                         sim_log_handlers = add_simulation_log_handlers(project_dir)
                     needs_setup = not verification_status["setup_done"]
+                    
+                    # Mark profiler if setup was cached/skipped
+                    if not needs_setup:
+                        self.profiler.phase_skipped = True
 
                     if needs_setup:
                         self.project_manager.create_new()
@@ -204,6 +208,10 @@ class FarFieldStudy(BaseStudy):
                     if verification_status["extract_done"]:
                         do_extract = False
                         self._log("Skipping extract phase, deliverables found.", log_type="info")
+                        # Upload results if reupload flag is set and running as assignment
+                        if self._should_reupload_results() and self.project_manager.project_path:
+                            project_dir = os.path.dirname(self.project_manager.project_path)
+                            self._upload_results_if_assignment(project_dir)
 
                     if self.gui:
                         self.gui.update_stage_progress("Setup", 1, 1)
@@ -220,21 +228,24 @@ class FarFieldStudy(BaseStudy):
                     project_dir = os.path.dirname(self.project_manager.project_path)
                     sim_log_handlers = add_simulation_log_handlers(project_dir)
 
-            import s4l_v1.document
+            # Get a fresh simulation handle from the document if we need to run or extract
+            # If everything is done, we don't need the simulation handle
+            if do_run or do_extract:
+                import s4l_v1.document
 
-            if s4l_v1.document.AllSimulations:
-                sim_name = f"EM_FDTD_{phantom_name}_{freq}MHz_{direction_name}_{polarization_name}"
-                simulation = next(
-                    (s for s in s4l_v1.document.AllSimulations if s.Name == sim_name),
-                    None,
-                )
+                if s4l_v1.document.AllSimulations:
+                    sim_name = f"EM_FDTD_{phantom_name}_{freq}MHz_{direction_name}_{polarization_name}"
+                    simulation = next(
+                        (s for s in s4l_v1.document.AllSimulations if s.Name == sim_name),
+                        None,
+                    )
 
-            if not simulation:
-                self._log(
-                    f"ERROR: No simulation found for {direction_name}_{polarization_name}.",
-                    log_type="error",
-                )
-                return
+                if not simulation:
+                    self._log(
+                        f"ERROR: No simulation found for {direction_name}_{polarization_name}.",
+                        log_type="error",
+                    )
+                    return
 
             # 2. Run Phase
             if do_run:

--- a/goliat/studies/far_field_study.py
+++ b/goliat/studies/far_field_study.py
@@ -151,7 +151,7 @@ class FarFieldStudy(BaseStudy):
                         project_dir = os.path.dirname(self.project_manager.project_path)
                         sim_log_handlers = add_simulation_log_handlers(project_dir)
                     needs_setup = not verification_status["setup_done"]
-                    
+
                     # Mark profiler if setup was cached/skipped
                     if not needs_setup:
                         self.profiler.phase_skipped = True

--- a/goliat/studies/near_field_study.py
+++ b/goliat/studies/near_field_study.py
@@ -227,7 +227,7 @@ class NearFieldStudy(BaseStudy):
                         project_dir = os.path.dirname(self.project_manager.project_path)
                         sim_log_handlers = add_simulation_log_handlers(project_dir)
                     needs_setup = not verification_status["setup_done"]
-                    
+
                     # Mark profiler if setup was cached/skipped
                     if not needs_setup:
                         self.profiler.phase_skipped = True


### PR DESCRIPTION
## Summary

This PR fixes a caching issue where setup_timestamp was not preserved when setup is skipped.

## Changes

- Add update_setup_timestamp parameter to write_simulation_metadata()
- Only update setup_timestamp when setup is actually performed
- Add phase_skipped attribute to Profiler
- Fixes issue where auto_cleanup caused unnecessary re-runs

## Related Issues

Closes #91