### PR TITLE
chore(deps): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     args: [--autofix, --trailing-commas]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.5
+  rev: v0.14.6
   hooks:
   - id: ruff-format
     exclude: ^(analysis/)
@@ -43,7 +43,7 @@ repos:
     - tomli
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.9
+  rev: 0.9.11
   hooks:
   - id: uv-lock
 


### PR DESCRIPTION
Updates pre-commit hooks to newer versions:
- ruff: v0.14.5 → v0.14.6
- uv: 0.9.9 → 0.9.11