### PR TITLE
feat(far-field): phantom bounding box reduction for high frequencies

### DIFF
--- a/docs/developer_guide/configuration.md
+++ b/docs/developer_guide/configuration.md
@@ -143,6 +143,9 @@ These settings define the spatial discretization of the simulation domain.
 | `padding.padding_mode` | string | `"automatic"` | Defines how padding is applied around the simulation domain. Can be `"automatic"` or `"manual"`. |
 | `padding.manual_bottom_padding_mm` | array | `[0, 0, 0]` | For manual padding, the [x, y, z] padding in millimeters at the bottom of the domain. |
 | `padding.manual_top_padding_mm` | array | `[0, 0, 0]` | For manual padding, the [x, y, z] padding in millimeters at the top of the domain. |
+| `phantom_bbox_reduction.auto_reduce_bbox` | boolean | `false` | **(Far-Field)** If `true`, enables automatic phantom height reduction for frequencies above `reference_frequency_mhz`. |
+| `phantom_bbox_reduction.reference_frequency_mhz` | number | `5800` | **(Far-Field)** The reference frequency where full-body simulation fits in memory. For higher frequencies, height is reduced by `(reference/current)³`. |
+| `phantom_bbox_reduction.height_limit_per_frequency_mm` | object | `{}` | **(Far-Field)** Manual height limits per frequency in mm (e.g., `{"10000": 400}`). Overrides automatic calculation. |
 
 <br>
 

--- a/docs/reference/full_features_list.md
+++ b/docs/reference/full_features_list.md
@@ -136,6 +136,9 @@ This document provides a complete reference of every feature available in GOLIAT
 - Manual padding configuration for bottom and top of domain [x, y, z]
 - Intelligent gridding around critical areas (finer cells near antenna/phantom surface)
 - Automatic gridding optimization for computational efficiency
+- Phantom bounding box reduction (far-field): Automatically truncate phantom height for high-frequency simulations to reduce cell count
+- Cubic frequency scaling: height_factor = (reference_freq / current_freq)³
+- Manual per-frequency height limits override automatic calculation
 
 ## Solver configuration
 


### PR DESCRIPTION
## Summary
Automatically reduce phantom bounding box height for high-frequency far-field simulations to manage cell count.

## Changes
- Add `phantom_bbox_reduction` config block in `gridding_parameters`
- Cubic frequency scaling: `height_factor = (reference_freq / current_freq)³`
- 20% minimum floor to ensure head remains in simulation
- Documentation updates

## Configuration
```json
"phantom_bbox_reduction": {
    "auto_reduce_bbox": true,
    "reference_frequency_mhz": 9000,
    "height_limit_per_frequency_mm": {}
}
```

## Example (Thelonious, ref: 9 GHz)
| Freq | Height Kept | Coverage |
|------|-------------|----------|
| 10 GHz | 875 mm | Upper body + thighs |
| 12 GHz | 506 mm | Head + torso |
| 15 GHz | 259 mm | Head + shoulders |

## Files
- `goliat/setups/far_field_setup.py`
- `docs/developer_guide/configuration.md`
- `docs/reference/full_features_list.md`